### PR TITLE
Made list#unique about 5 times faster.

### DIFF
--- a/list.vim
+++ b/list.vim
@@ -6,18 +6,9 @@
 " Remove duplicate values from {list} in-place (preserves order).
 
 function! xolox#misc#list#unique(list)
-  let index = 0
-  while index < len(a:list)
-    let value = a:list[index]
-    let match = index(a:list, value, index+1)
-    if match >= 0
-      call remove(a:list, match)
-    else
-      let index += 1
-    endif
-    unlet value
-  endwhile
-  return a:list
+  call reverse(a:list)
+  call filter(a:list, 'count(a:list, v:val) == 1')
+  return reverse(a:list)
 endfunction
 
 " Binary insertion (more efficient than calling sort() after each insertion).


### PR DESCRIPTION
Hoi Peter,

Terwijl ik aan het werk was aan onze python ftplugin had ik een functie nodig om dubbele waarden uit een lijst te halen. Pas nadat ik dit had geimplementeerd dacht ik ineens: het moet wel heel gek lopen als dit niet in Peter zijn misc library zit. Dit was er ook, maar behoorlijk anders en aanzienlijk trager. Ik heb de vrijheid genomen je project te forken en een patch te maken.

Ik heb de functies op snelheid getest met een niet al te grote lijst. Al denk ik niet dat de grotte uberhaupt verschil zal maken. De volgorde van de lijst blijft gelijk net zoals jou originele implementatie.

Groeten,
Bart
