### PR TITLE
FIX: path#which() does not handle already existing Windows file extensio...

### DIFF
--- a/autoload/xolox/misc/path.vim
+++ b/autoload/xolox/misc/path.vim
@@ -22,16 +22,26 @@ function! xolox#misc#path#which(...) " {{{1
   let matches = []
   let checked = {}
   for program in a:000
-    for extension in extensions
-      for directory in split($PATH, s:windows_compatible ? ';' : ':')
-        let directory = xolox#misc#path#absolute(directory)
-        if isdirectory(directory)
+    for directory in split($PATH, s:windows_compatible ? ';' : ':')
+      let directory = xolox#misc#path#absolute(directory)
+      if isdirectory(directory)
+        let found = 0
+        for extension in extensions
           let path = xolox#misc#path#merge(directory, program . extension)
+          if executable(path)
+            call add(matches, path)
+            let found = 1
+          endif
+        endfor
+        if s:windows_compatible && ! found
+          " Maybe the extension is already contained in program; try without
+          " $PATHEXT.
+          let path = xolox#misc#path#merge(directory, program)
           if executable(path)
             call add(matches, path)
           endif
         endif
-      endfor
+      endif
     endfor
   endfor
   return matches


### PR DESCRIPTION
I found this problem while checking out your easytags _async_ branch. My `v:progname` yields `gvim.exe`, which the plugin translated into the empty string.

When I invoke `xolox#misc#path#which('gvim.exe')` on Windows, nothing is returned. The problem is that all file extensions in $PATHEXT are appended, but it is not checked whether the passed program as-is is executable. Let's do that last when no extension yields a match; this avoids that BOTH .../gvim and .../gvim.exe are returned.

Additionally, the iteration logic is wrong. Windows does not check all PATH components for .BAT files, then check all for .EXE etc. Instead, executables in an earlier component of PATH are preferred, regardless of the order of the file extension in PATHEXT. Therefore, swap the inner and outer loop. It's also more efficient, because xolox#misc#path#absolute(directory) is only done once for each component.
