### PR TITLE
Avoid the costly shelling out to uname when on Windows.

### DIFF
--- a/autoload/xolox/misc/os.vim
+++ b/autoload/xolox/misc/os.vim
@@ -16,7 +16,7 @@ function! xolox#misc#os#is_mac() " {{{1
     if has('mac') || has('macunix') || has('gui_mac')
       " If Vim's feature list indicates we are on Mac OS X, we have our answer :-).
       let s:is_mac = 1
-    else
+    elseif !xolox#misc#os#is_win()
       " Otherwise we check the output of `uname' to avoid false negatives.
       let result = xolox#misc#os#exec({'command': 'uname', 'check': 0})
       if result['exit_code'] == 0 && get(result['stdout'], 0, '') == 'Darwin'


### PR DESCRIPTION
As `xolox#misc#os#is_mac()` is invoked in some places without a previous conditional on `xolox#misc#os#is_win()`, avoid shelling out to uname for the Mac OS check when we can already cheaply determine via `has()` that we're on Windows.
