### PR TITLE
Change the hlgroup of xolox#misc#msg#info

### DIFF
--- a/autoload/xolox/misc/msg.vim
+++ b/autoload/xolox/misc/msg.vim
@@ -25,7 +25,7 @@ function! xolox#misc#msg#info(...) " {{{1
   "
   " [printf()]: http://vimdoc.sourceforge.net/htmldoc/eval.html#printf()
   " [string()]: http://vimdoc.sourceforge.net/htmldoc/eval.html#string()
-  call s:show_message('title', a:000)
+  call s:show_message('None', a:000)
 endfunction
 
 function! xolox#misc#msg#warn(...) " {{{1
@@ -33,7 +33,7 @@ function! xolox#misc#msg#warn(...) " {{{1
   "
   " This function has the same argument handling as the
   " `xolox#misc#msg#info()` function.
-  call s:show_message('warningmsg', a:000)
+  call s:show_message('WarningMsg', a:000)
 endfunction
 
 function! xolox#misc#msg#debug(...) " {{{1
@@ -50,7 +50,7 @@ function! xolox#misc#msg#debug(...) " {{{1
   "
   " ['verbose']: http://vimdoc.sourceforge.net/htmldoc/options.html#'verbose'
   if &vbs >= 1
-    call s:show_message('question', a:000)
+    call s:show_message('Question', a:000)
   endif
 endfunction
 


### PR DESCRIPTION
It used the hlgroup `'Title'`, but this does not accurately represent an informational message. As one can see from [`:help hl-Title`](http://vimdoc.sourceforge.net/htmldoc/syntax.html#hl-Title) and the example commands it lists, `'Title'` is meant for section headings in long output, not a single-line message.

This inapplicability was especially noticeable in my color scheme (Solarized), which shows `'Title'` in an orange-red color. This color does a good job of marking titles in long output, but it makes a single-line message look like an error.

Instead, I have made `#info` use no highlighting – the hlgroup `'None'`. I think this hlgroup most accurately represents an “informational message”. It is the same hlgroup that searches are echoed with when pressing `n` and `N`, which also seem like informational messages.

While I am editing hlgroups, I also made the capitalization of their names the same as what Vim uses when you run the `:highlight` command. This makes multi-word names a little easier to read, and aids debugging against the output of `:highlight`.

Before:

![before: an info message from vim-session that looks like an error message](https://cloud.githubusercontent.com/assets/79168/4622888/43a6eb9a-5342-11e4-9db5-539e4703e03c.png)

After:

![after: an info message from vim-session that properly looks like an info message](https://cloud.githubusercontent.com/assets/79168/4622889/4780506c-5342-11e4-9d78-b1ad878a49ad.png)
