### PR TITLE
testing if the filesystem is case sensitive

### DIFF
--- a/autoload/xolox/misc/os.vim
+++ b/autoload/xolox/misc/os.vim
@@ -32,6 +32,11 @@ function! xolox#misc#os#is_win() " {{{1
   return has('win16') || has('win32') || has('win64')
 endfunction
 
+function! xolox#misc#os#is_fs_case_sensitive() " {{{1
+  " Returns 1 (true) when the filesystem is case sensitive 
+  return !xolox#misc#os#is_win() && !has('win32unix')
+endfunction
+
 function! xolox#misc#os#find_vim(...) " {{{1
   " Returns the program name of Vim as a string. On Windows and UNIX this just
   " [v:progname] [] as an absolute pathname while on Mac OS X there is

--- a/autoload/xolox/misc/path.vim
+++ b/autoload/xolox/misc/path.vim
@@ -226,13 +226,13 @@ endfunction
 
 " xolox#misc#path#equals(a, b) - Check whether two pathnames point to the same file. {{{1
 
-if s:windows_compatible
+if xolox#misc#os#is_fs_case_sensitive()
   function! xolox#misc#path#equals(a, b)
-    return a:a ==? a:b || xolox#misc#path#absolute(a:a) ==? xolox#misc#path#absolute(a:b)
+    return a:a ==# a:b || xolox#misc#path#absolute(a:a) ==# xolox#misc#path#absolute(a:b)
   endfunction
 else
   function! xolox#misc#path#equals(a, b)
-    return a:a ==# a:b || xolox#misc#path#absolute(a:a) ==# xolox#misc#path#absolute(a:b)
+    return a:a ==? a:b || xolox#misc#path#absolute(a:a) ==? xolox#misc#path#absolute(a:b)
   endfunction
 endif
 


### PR DESCRIPTION
Hi,

I ran insome trouble while using vim-notes on Windows with vim is opened in a Cgywin console. My file absolute path as calculate in xolox#notes#save function - let oldpath = expand('%:p') - differs from the one calculated for the g:notes_directories (by some reason - expand('<sfile>:p:h') - returns the script folder in lower cases on Windows/Cygwin). By having this this difference, I getmy note deleted by xolox#notes#save function when trying to rename file.

While I think this issue needs to be addressed in the xolox#notes#save function, that should guarantee that a note won't be deleted, I worked on the misc API and added a test to check the filesystem.
