### PR TITLE
Add `:silent` in xolox#misc#os#is_mac() to prevent junk on terminal.

### DIFF
--- a/autoload/xolox/misc/os.vim
+++ b/autoload/xolox/misc/os.vim
@@ -18,7 +18,7 @@ function! xolox#misc#os#is_mac() " {{{1
       let s:is_mac = 1
     elseif !xolox#misc#os#is_win()
       " Otherwise we check the output of `uname' to avoid false negatives.
-      let result = xolox#misc#os#exec({'command': 'uname', 'check': 0})
+      silent let result = xolox#misc#os#exec({'command': 'uname', 'check': 0})
       if result['exit_code'] == 0 && get(result['stdout'], 0, '') == 'Darwin'
         let s:is_mac = 1
       endif


### PR DESCRIPTION
The function `xolox#misc#os#is_mac()` uses Vim's `system()` function to
invoke `uname` for platform detection.  By default, Vim's `system()`
function sets the terminal to "cooked" mode during execution of the
external program.  Normally this would not be a problem, but there are
some sensitive moments during Vim startup where terminal settings are
being negotiated; at these times, changing to "cooked" mode can disrupt
this negotiation.

In particular, the vim-session plugin uses this `is_mac()` function
during a `VimEnter` auto-command.  When processing `VimEnter`, terminals
such as Kitty are in the midst of terminal negotiations.  The visible
effect is that escape sequences such as the below may end up on screen
after invoking `vim` with no arguments:

  ^[[2;2R^[[3;1R^[[>1;4000;20c^[]10;rgb:dddd/dddd/dddd^[\^[]11;rgb:0000/0000/0000^[\

To avoid this, use `:silent` with `system()` as recommended in
`:help system()`.

This problem can be demonstrated in complete isolation from any plugins
by having an empty `~/.vim` directory and the below three lines as the
sole contents of `~/.vimrc`:

  augroup Something
  au VimEnter * call system("true", "")
  augroup END

Using Kitty, the above will reliable generate the junk characters shown
above when invoking `vim` with no arguments.